### PR TITLE
Add centralized MapperConfig and update mappers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.3.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>mate.academy</groupId>
@@ -51,6 +51,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-core</artifactId>
+            <version>2.10.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
             <version>${mapstruct.version}</version>
@@ -87,7 +92,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <phase>compile</phase>

--- a/src/main/java/mate/academy/mapstruct/config/MapperConfig.java
+++ b/src/main/java/mate/academy/mapstruct/config/MapperConfig.java
@@ -1,0 +1,13 @@
+package mate.academy.mapstruct.config;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.NullValueCheckStrategy;
+
+@org.mapstruct.MapperConfig(
+        componentModel = "spring",
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS,
+        implementationPackage = "<PACKAGE_NAME>.impl"
+)
+public class MapperConfig {
+}

--- a/src/main/java/mate/academy/mapstruct/mapper/GroupMapper.java
+++ b/src/main/java/mate/academy/mapstruct/mapper/GroupMapper.java
@@ -1,11 +1,23 @@
 package mate.academy.mapstruct.mapper;
 
+import java.util.Optional;
+import mate.academy.mapstruct.config.MapperConfig;
 import mate.academy.mapstruct.dto.group.CreateGroupRequestDto;
 import mate.academy.mapstruct.dto.group.GroupDto;
 import mate.academy.mapstruct.model.Group;
+import org.mapstruct.Mapper;
+import org.mapstruct.Named;
 
+@Mapper(config = MapperConfig.class)
 public interface GroupMapper {
     GroupDto toDto(Group group);
 
     Group toModel(CreateGroupRequestDto requestDto);
+
+    @Named("groupById")
+    default Group groupById(Long id) {
+        return Optional.ofNullable(id)
+                .map(Group::new)
+                .orElse(null);
+    }
 }

--- a/src/main/java/mate/academy/mapstruct/mapper/StudentMapper.java
+++ b/src/main/java/mate/academy/mapstruct/mapper/StudentMapper.java
@@ -1,14 +1,43 @@
 package mate.academy.mapstruct.mapper;
 
+import java.util.List;
+import mate.academy.mapstruct.config.MapperConfig;
 import mate.academy.mapstruct.dto.student.CreateStudentRequestDto;
 import mate.academy.mapstruct.dto.student.StudentDto;
 import mate.academy.mapstruct.dto.student.StudentWithoutSubjectsDto;
 import mate.academy.mapstruct.model.Student;
+import mate.academy.mapstruct.model.Subject;
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 
+@Mapper(config = MapperConfig.class, uses = GroupMapper.class)
 public interface StudentMapper {
+    @Mapping(source = "group.id", target = "groupId")
+    @Mapping(target = "subjectIds", ignore = true)
     StudentDto toDto(Student student);
 
+    @AfterMapping
+    default void setSubjectIds(@MappingTarget StudentDto studentDto, Student student) {
+        List<Long> subjectIds = student.getSubjects().stream()
+                .map(Subject::getId)
+                .toList();
+        studentDto.setSubjectIds(subjectIds);
+    }
+
+    @Mapping(source = "group.id", target = "groupId")
     StudentWithoutSubjectsDto toStudentWithoutSubjectsDto(Student student);
 
+    @Mapping(target = "group", source = "groupId", qualifiedByName = "groupById")
+    @Mapping(target = "subjects", ignore = true)
     Student toModel(CreateStudentRequestDto requestDto);
+
+    @AfterMapping
+    default void setSubjects(@MappingTarget Student student, CreateStudentRequestDto requestDto) {
+        List<Subject> subjects = requestDto.subjects().stream()
+                .map(Subject::new)
+                .toList();
+        student.setSubjects(subjects);
+    }
 }

--- a/src/main/java/mate/academy/mapstruct/mapper/SubjectMapper.java
+++ b/src/main/java/mate/academy/mapstruct/mapper/SubjectMapper.java
@@ -1,9 +1,12 @@
 package mate.academy.mapstruct.mapper;
 
+import mate.academy.mapstruct.config.MapperConfig;
 import mate.academy.mapstruct.dto.subject.CreateSubjectRequestDto;
 import mate.academy.mapstruct.dto.subject.SubjectDto;
 import mate.academy.mapstruct.model.Subject;
+import org.mapstruct.Mapper;
 
+@Mapper(config = MapperConfig.class)
 public interface SubjectMapper {
     SubjectDto toDto(Subject subject);
 


### PR DESCRIPTION
Introduce a centralized MapperConfig and apply it to all existing mappers to standardize configurations. Upgrade Spring Boot version and add xmlunit dependency. Enhance StudentMapper with subject ID mappings and GroupMapper with group lookup by ID.